### PR TITLE
Create module for Azure Stack fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/cluster-api-provider-azure
+module github.com/openshift/cluster-api-provider-azurestack
 
 go 1.22.7
 
@@ -57,6 +57,7 @@ require (
 	k8s.io/utils v0.0.0-20240821151609-f90d01438635
 	sigs.k8s.io/cloud-provider-azure v1.30.4
 	sigs.k8s.io/cluster-api v1.9.5
+	sigs.k8s.io/cluster-api-provider-azure v1.19.1
 	sigs.k8s.io/cluster-api/test v1.9.5
 	sigs.k8s.io/controller-runtime v0.19.6
 	sigs.k8s.io/kind v0.27.0
@@ -231,3 +232,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azurestack v0.0.0-20250405115711-366c18de8463

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b h1:YWuSjZCQAPM8UUBLkYUk1e+rZcvWHJmFb6i6rM44Xs8=
 github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
+github.com/openshift/cluster-api-provider-azurestack v0.0.0-20250405115711-366c18de8463 h1:LfHf5KJompYG1cwmVIvLF48aydc4urZLp8AO+lWqCj4=
+github.com/openshift/cluster-api-provider-azurestack v0.0.0-20250405115711-366c18de8463/go.mod h1:g7lz7uqp4uN7w/kVRKQ4GVJUhQXPwJMx994mwkteaSA=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=


### PR DESCRIPTION
Renames the go module to be for azure stack, to allow clean importing:

1. Rename module
2. Replace all calls to CAPZ to calls to this fork.

The replace call will need to be bumped whenever we rebase:

```
go mod edit -replace=sigs.k8s.io/cluster-api-provider-azure=github.com/openshift/cluster-api-provider-azurestack@main
```