### PR TITLE
CARRY: skip managed publicIP check

### DIFF
--- a/azure/services/publicips/publicips.go
+++ b/azure/services/publicips/publicips.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4"
-	"github.com/pkg/errors"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
@@ -120,10 +119,15 @@ func (s *Service) Delete(ctx context.Context) error {
 	//  Order of precedence (highest -> lowest) is: error that is not an operationNotDoneError (i.e. error deleting) -> operationNotDoneError (i.e. deleting in progress) -> no error (i.e. deleted)
 	var result error
 	for _, publicIPSpec := range specs {
-		managed, err := s.isIPManaged(ctx, publicIPSpec)
-		if err != nil && !azure.ResourceNotFound(err) {
-			return errors.Wrap(err, "could not get public IP management state")
-		}
+		// managed, err := s.isIPManaged(ctx, publicIPSpec)
+		// if err != nil && !azure.ResourceNotFound(err) {
+		// 	return errors.Wrap(err, "could not get public IP management state")
+		// }
+
+		//The above code breaks in AzureStack as it doesn't support getting tags by scope.
+		// We don't need to support managed IPs anyway so it is safe to skip, but would need to be
+		// addressed more completely to merge upstream.
+		managed := true
 
 		if !managed {
 			log.V(2).Info("Skipping IP deletion for unmanaged public IP", "public ip", publicIPSpec.ResourceName())


### PR DESCRIPTION
Azure Stack breaks when deleting public IP checks because there is a call to get tags by scope, which is not supported on Azure Stack. We can safely skip it but would need a more complete solution to merge upstream. Fixes:

time="2025-04-09T08:34:53Z" level=debug msg="\terror deleting AzureMachine openshift-cluster-api-guests/jimaashtest-n5q87-bootstrap: failed to delete AzureMachine service publicips: could not get public IP management state:
 GET https://management.mtcazs.wwtatc.com/subscriptions/d751283a-64fa-401b-92a1-58f1750ac0a7/resourceGroups/jima-ex-rg/providers/Microsoft.Network/publicIPAddresses/pip-jimaashtest-n5q87-bootstrap/providers/Microsoft.Resources/tags/default"

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->


**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] cherry-pick candidate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
